### PR TITLE
Add the ability to customize the installed package name

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -52,6 +52,7 @@ The following parameters are available in the `openvoxview` class:
 * [`puppetdb_tls_cert_path`](#-openvoxview--puppetdb_tls_cert_path)
 * [`download_url`](#-openvoxview--download_url)
 * [`install_method`](#-openvoxview--install_method)
+* [`package_name`](#-openvoxview--package_name)
 
 ##### <a name="-openvoxview--version"></a>`version`
 
@@ -260,4 +261,12 @@ Data type: `Enum['archive', 'package']`
 Installation method, either 'archive' or 'package'
 
 Default value: `'archive'`
+
+##### <a name="-openvoxview--package_name"></a>`package_name`
+
+Data type: `String`
+
+Name of the package to install
+
+Default value: `'openvoxview'`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,8 +79,12 @@
 # @param install_method
 #   Installation method, either 'archive' or 'package'
 #
+# @param package_name
+#   Name of the package to install
+#
 class openvoxview (
   Enum['archive', 'package']     $install_method         = 'archive',
+  String                         $package_name           = 'openvoxview',
   String                         $version                = '1.4.0',
   Stdlib::HTTPUrl                $download_url           = "https://github.com/voxpupuli/openvoxview/releases/download/v${version}/openvoxview_${version}_linux_amd64.tar.gz",
   Boolean                        $manage_config_dir      = true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -51,6 +51,7 @@ class openvoxview::install {
       $executable_path = '/usr/bin/openvoxview'
       package { 'openvoxview':
         ensure => $openvoxview::version,
+        name   => $openvoxview::package_name,
         notify => $notify_service_maybe,
       }
     }


### PR DESCRIPTION
#### Pull Request (PR) description

This pull request adds the ability to customize the installed package name.  It is used, for example, when you use gentoo because you need to specify a category parameter to disambiguate any potential multiple matches.