### PR TITLE
Support for puppetca configuration

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -53,6 +53,15 @@ The following parameters are available in the `openvoxview` class:
 * [`download_url`](#-openvoxview--download_url)
 * [`install_method`](#-openvoxview--install_method)
 * [`package_name`](#-openvoxview--package_name)
+* [`puppetca_host`](#-openvoxview--puppetca_host)
+* [`puppetca_port`](#-openvoxview--puppetca_port)
+* [`puppetca_tls`](#-openvoxview--puppetca_tls)
+* [`puppetca_tls_ignore`](#-openvoxview--puppetca_tls_ignore)
+* [`puppetca_tls_ca`](#-openvoxview--puppetca_tls_ca)
+* [`puppetca_tls_key`](#-openvoxview--puppetca_tls_key)
+* [`puppetca_tls_crt`](#-openvoxview--puppetca_tls_crt)
+* [`puppetca_readonly`](#-openvoxview--puppetca_readonly)
+* [`puppetca_deactivate_nodes`](#-openvoxview--puppetca_deactivate_nodes)
 * [`log_level`](#-openvoxview--log_level)
 * [`log_format`](#-openvoxview--log_format)
 
@@ -271,6 +280,78 @@ Data type: `String`
 Name of the package to install
 
 Default value: `'openvoxview'`
+
+##### <a name="-openvoxview--puppetca_host"></a>`puppetca_host`
+
+Data type: `Optional[String]`
+
+Address of Puppet CA server (optional)
+
+Default value: `undef`
+
+##### <a name="-openvoxview--puppetca_port"></a>`puppetca_port`
+
+Data type: `Integer[1024, 65535]`
+
+Port of Puppet CA server
+
+Default value: `8140`
+
+##### <a name="-openvoxview--puppetca_tls"></a>`puppetca_tls`
+
+Data type: `Boolean`
+
+Use TLS for Puppet CA communications
+
+Default value: `true`
+
+##### <a name="-openvoxview--puppetca_tls_ignore"></a>`puppetca_tls_ignore`
+
+Data type: `Boolean`
+
+Ignore validation of TLS certificate
+
+Default value: `false`
+
+##### <a name="-openvoxview--puppetca_tls_ca"></a>`puppetca_tls_ca`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Path to CA cert file for Puppet CA
+
+Default value: `undef`
+
+##### <a name="-openvoxview--puppetca_tls_key"></a>`puppetca_tls_key`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Path to client key file for Puppet CA
+
+Default value: `undef`
+
+##### <a name="-openvoxview--puppetca_tls_crt"></a>`puppetca_tls_crt`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Path to client cert file for Puppet CA
+
+Default value: `undef`
+
+##### <a name="-openvoxview--puppetca_readonly"></a>`puppetca_readonly`
+
+Data type: `Boolean`
+
+Whether to allow signing / revoking / cleaning certs
+
+Default value: `true`
+
+##### <a name="-openvoxview--puppetca_deactivate_nodes"></a>`puppetca_deactivate_nodes`
+
+Data type: `Boolean`
+
+Also deactivate node in PuppetDB with revoke / clean
+
+Default value: `false`
 
 ##### <a name="-openvoxview--log_level"></a>`log_level`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,17 @@ class openvoxview::config {
     queries    => $openvoxview::predefined_pql_queries,
     log_level  => $openvoxview::log_level,
     log_format => $openvoxview::log_format,
+    puppetca   => {
+      host             => $openvoxview::puppetca_host,
+      port             => $openvoxview::puppetca_port,
+      tls              => $openvoxview::puppetca_tls,
+      tls_ignore       => $openvoxview::puppetca_tls_ignore,
+      tls_ca           => $openvoxview::puppetca_tls_ca,
+      tls_key          => $openvoxview::puppetca_tls_key,
+      tls_crt          => $openvoxview::puppetca_tls_crt,
+      readonly         => $openvoxview::puppetca_readonly,
+      deactivate_nodes => $openvoxview::puppetca_deactivate_nodes,
+    },
   }
 
   if $openvoxview::manage_config_dir {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,32 @@
 #
 # @param package_name
 #   Name of the package to install
+# @param puppetca_host
+#   Address of Puppet CA server (optional)
+#
+# @param puppetca_port
+#   Port of Puppet CA server
+#
+# @param puppetca_tls
+#   Use TLS for Puppet CA communications
+#
+# @param puppetca_tls_ignore
+#   Ignore validation of TLS certificate
+#
+# @param puppetca_tls_ca
+#   Path to CA cert file for Puppet CA
+#
+# @param puppetca_tls_key
+#   Path to client key file for Puppet CA
+#
+# @param puppetca_tls_crt
+#   Path to client cert file for Puppet CA
+#
+# @param puppetca_readonly
+#   Whether to allow signing / revoking / cleaning certs
+#
+# @param puppetca_deactivate_nodes
+#   Also deactivate node in PuppetDB with revoke / clean
 #
 # @param log_level
 #   Log level
@@ -118,6 +144,15 @@ class openvoxview (
   Optional[Stdlib::Absolutepath] $puppetdb_tls_cert_path = undef,
   Optional[Enum['debug','info','warn','error']] $log_level = undef,
   Optional[Enum['text','json']] $log_format = undef,
+  Optional[String] $puppetca_host = undef,
+  Integer[1024, 65535] $puppetca_port = 8140,
+  Boolean $puppetca_tls = true,
+  Boolean $puppetca_tls_ignore = false,
+  Optional[Stdlib::Absolutepath] $puppetca_tls_ca = undef,
+  Optional[Stdlib::Absolutepath] $puppetca_tls_key = undef,
+  Optional[Stdlib::Absolutepath] $puppetca_tls_crt = undef,
+  Boolean $puppetca_readonly = true,
+  Boolean $puppetca_deactivate_nodes = false,
 ) {
   if ($manage_group) {
     group { $openvoxview_group:


### PR DESCRIPTION
This PR follow-up #27 and add support for configuring the CA web interface introduced in [v1.3.0](https://github.com/voxpupuli/openvoxview/releases/tag/v1.3.0).