### PR TITLE
Stop adding empty log options by default

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,7 +22,7 @@ class openvoxview::config {
     queries    => $openvoxview::predefined_pql_queries,
     log_level  => $openvoxview::log_level,
     log_format => $openvoxview::log_format,
-  }
+  }.filter |$_, $v| { $v =~ NotUndef }
 
   if $openvoxview::manage_config_dir {
     file { $openvoxview::config_dir:

--- a/spec/classes/openvoxview_spec.rb
+++ b/spec/classes/openvoxview_spec.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'yaml'
 
 describe 'openvoxview' do
+  let(:config_data) do
+    x = catalogue.resource('file', '/etc/openvox/openvox.yml').send(:parameters)
+    YAML.safe_load(x[:content])
+  end
+
   on_supported_os.each do |os, facts|
     context "on #{os} with default settings" do
       let(:facts) do
@@ -17,12 +23,17 @@ describe 'openvoxview' do
       it { is_expected.to contain_user('openvoxview').with_gid('openvoxview') }
       it { is_expected.to contain_archive('/tmp/openvoxview-1.5.0.tar.gz') }
       it { is_expected.to contain_file('/etc/openvox').with_ensure('directory') }
-      it { is_expected.to contain_file('/etc/openvox/openvox.yml') }
       it { is_expected.to contain_file('/opt/openvoxview-1.5.0').with_ensure('directory') }
       it { is_expected.to contain_file('/opt/openvoxview-1.5.0/openvoxview') }
       it { is_expected.to contain_file('/usr/local/bin/openvoxview').with_target('/opt/openvoxview-1.5.0/openvoxview') }
       it { is_expected.to contain_systemd__unit_file('openvoxview.service') }
       it { is_expected.to contain_service('openvoxview') }
+
+      it do
+        is_expected.to contain_file('/etc/openvox/openvox.yml')
+          .without_content(%r{^log_level:})
+          .without_content(%r{^log_format:})
+      end
     end
 
     context "on #{os} with custom settings" do
@@ -47,6 +58,18 @@ describe 'openvoxview' do
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('openvoxview::install') }
       it { is_expected.to contain_package('openvoxview') }
+    end
+
+    context 'with log_level' do
+      let(:params) { { log_level: 'warn' } }
+
+      it { expect(config_data['log_level']).to eq('warn') }
+    end
+
+    context 'with log_format' do
+      let(:params) { { log_format: 'json' } }
+
+      it { expect(config_data['log_format']).to eq('json') }
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Log options introduced in #32, were added to the config file even when set to undef. This PR improves the behavior.